### PR TITLE
add column_header method

### DIFF
--- a/lib/csvbuilder/core/concerns/model/attributes.rb
+++ b/lib/csvbuilder/core/concerns/model/attributes.rb
@@ -30,7 +30,7 @@ module Csvbuilder
         # @param [Hash, OpenStruct] context name of column to check
         # @return [Array] column headers for the row model
         def headers(context = {})
-          column_names.map { |column_name| Header.new(column_name, self, context).value }
+          column_names.map { |column_name| column_header(column_name, context) }
         end
 
         # Safe to override
@@ -53,6 +53,13 @@ module Csvbuilder
         end
 
         protected
+
+        # @param context [Hash, OpenStruct] name of column to check
+        # @param column_name [Symbol] the cell's column_name
+        # @return [String] column header
+        def column_header(column_name, context = {})
+          Header.new(column_name, self, context).value
+        end
 
         # Adds column to the row model
         #

--- a/lib/csvbuilder/core/concerns/model/attributes.rb
+++ b/lib/csvbuilder/core/concerns/model/attributes.rb
@@ -15,6 +15,10 @@ module Csvbuilder
         self.class.headers(context)
       end
 
+      def column_header(column_header)
+        self.class.column_header(column_header, context)
+      end
+
       class_methods do
         # @return [Array<Symbol>] column names for the row model
         def column_names
@@ -52,14 +56,14 @@ module Csvbuilder
           self._columns ||= {}
         end
 
-        protected
-
         # @param context [Hash, OpenStruct] name of column to check
         # @param column_name [Symbol] the cell's column_name
         # @return [String] column header
         def column_header(column_name, context = {})
           Header.new(column_name, self, context).value
         end
+
+        protected
 
         # Adds column to the row model
         #

--- a/spec/csvbuilder/core/concerns/model/attributes_spec.rb
+++ b/spec/csvbuilder/core/concerns/model/attributes_spec.rb
@@ -34,6 +34,14 @@ module Csvbuilder
           end
         end
 
+        describe "::column_header" do
+          it "returns the expected header for the given column name" do
+            {alpha: "Alpha", beta: "Beta Two", gamma: "#<OpenStruct foo=:bar> Gamma"}.each do |attr, header|
+              expect(klass.column_header(attr, { foo: :bar })).to eql header
+            end
+          end
+        end
+
         describe "::format_cell" do
           subject(:format_cell) { BasicRowModel.format_cell(cell, nil, nil) }
 


### PR DESCRIPTION
with a view to change how we find row values to use CSV::Row, we need to specify the column_header at the point we assign the value. This is currently done per column_name so we need a method to find the column_header per column_name also.